### PR TITLE
color-theme dependency reset to 6.5.5

### DIFF
--- a/color-theme-railscasts.el
+++ b/color-theme-railscasts.el
@@ -9,7 +9,7 @@
 ;; Keywords: railscasts color theme
 ;; URL: https://github.com/olegshaldybin/color-theme-railscasts
 ;; Version: 0.0.2
-;; Package-Requires: ((color-theme "6.6.1"))
+;; Package-Requires: ((color-theme "6.5.5"))
 
 ;; This file is NOT a part of GNU Emacs.
 


### PR DESCRIPTION
`color-theme` package's latest version is [6.5.5](http://marmalade-repo.org/packages/color-theme). Specifying it as `6.6.1` means it's impossible to install this theme on a fresh emacs install.

Looks like it was downgraded from 6.6.1, from this [pull request](https://github.com/sellout/emacs-color-theme-solarized/pull/45). Anyway, this change makes the requirement `color-theme 6.5.5`.
